### PR TITLE
Update seller RSS feed to include shipping address and timestamp

### DIFF
--- a/djangoApp/orders/feeds.py
+++ b/djangoApp/orders/feeds.py
@@ -23,7 +23,11 @@ class LatestSellerSalesFeed(Feed):
         return f"Sale: {item.quantity} x {item.product_name}"
 
     def item_description(self, item):
-        return f"Order #{item.order.id} | Unit Price: ${item.unit_price} | Total: ${item.line_total}"
+        address = f"{item.order.street}, {item.order.state}, {item.order.zip_code}, {item.order.country}"
+        return f"Order #{item.order.id} | Unit Price: ${item.unit_price} | Total: ${item.line_total} | Ship-to: {address}"
+
+    def item_pubdate(self, item):
+        return item.created_at
 
     def item_link(self, item):
         return reverse('sales_history')


### PR DESCRIPTION
This PR updates the seller RSS feed to explicitly include the ship-to address and the date/time of the order being placed to fulfill the project requirements.